### PR TITLE
Typo fixes in readme and Transaction Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ For all Form objects returned by FormBuilder methods
 // read form parameters
 $httpMethod = $form->getMethod();
 $actionUrl = $form->getAction();
-$fields = $form->getFields(); 
+$parameters = $form->getParameters(); 
 
-// Header fields as key => value array
-foreach ($fields as $key => $value) {
+// Header parameters as key => value array
+foreach ($parameters as $key => $value) {
 	echo $key .":". $value;
 }
 ```

--- a/src/Model/Request/Transaction.php
+++ b/src/Model/Request/Transaction.php
@@ -29,7 +29,7 @@ class Transaction implements \JsonSerializable
     {
         $this->amount = $amount;
         $this->currency = $currency;
-        $this->order = $orderId;
+        $this->orderId = $orderId;
         $this->blocking = $blocking;
 
         $this->setRequestByType($request);


### PR DESCRIPTION
Fixed readme: Form::getFields() doesn't exist, it's Form::getParameters() instead.

Fixed typo in Transaction Model constructor: order -> orderId